### PR TITLE
Update scratch org definitions to use settings

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Athena - Beta Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Athena - Dev Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Athena - Feature Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Athena - Release Test Org",
   "edition": "Enterprise",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }

--- a/orgs/walkthrough.json
+++ b/orgs/walkthrough.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Athena - Walkthrough Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings" : {
+    "orgPreferenceSettings": {
+        "s1DesktopEnabled": true,
+        "chatterEnabled": true
+    }
   }
 }


### PR DESCRIPTION
`orgPreferences` were deprecated and are generating a warning.