### PR TITLE
Updating uninstall_packaged_incremental to ignore the standard quick actions

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -59,6 +59,20 @@ tasks:
             path: unpackaged/config/trial
             namespace_tokenize: $project_config.project__package__namespace
 
+    uninstall_packaged_incremental:
+        class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
+        options:
+            ignore:
+                QuickAction:
+                    - LogACall
+                    - NewCase
+                    - NewContact
+                    - NewEvent
+                    - NewLead
+                    - NewNote
+                    - NewTask
+                    - SendEmail
+
 flows:
     config_managed:
         steps:
@@ -100,12 +114,6 @@ flows:
                     namespaced_org: True
             6:
                 task: snapshot_changes
-
-    deploy_unmanaged:
-        steps:
-            4:
-                # Disable uninstall_packaged_incremental
-                task: None
 
 plans:
     install:


### PR DESCRIPTION
This fixes a beta build failure with the K-12 Kit 1.1 release.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
