### PR TITLE
Remove k12 kit settings step from installer.

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -144,10 +144,6 @@ plans:
             3:
                 task: install_managed
             4:
-                task: deploy_k12_kit_settings
-                ui_options:
-                    name: K12 - Default Kit Settings
-            5:
                 task: deploy_post
                 ui_options:
                     config:


### PR DESCRIPTION
Per @lifewithryan, remove this step from the installer. Our intention
moving forward is for the installer to include minimal configuration
only.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
