### PR TITLE
W-037392: fixing errant K12 and changing to K-12 in List View label

### DIFF
--- a/unpackaged/post/config/objects/hed__Course_Enrollment__c.object
+++ b/unpackaged/post/config/objects/hed__Course_Enrollment__c.object
@@ -98,7 +98,7 @@
             <operation>equals</operation>
             <value>Current</value>
         </filters>
-        <label>K12 Students Current Course Connections</label>
+        <label>K-12 Students Current Course Connections</label>
     </listViews>
     <recordTypes>
         <fullName>Faculty</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
Changed the label of the "K12 Students Current Course Connections" list view to align with the K-12 Architecture Kit rebranding.
# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
