### PR TITLE
fixing Student & Guardians by Household report

### DIFF
--- a/unpackaged/post/config/reports/unfiled$public/Students_and_Guardians_By_Household.report
+++ b/unpackaged/post/config/reports/unfiled$public/Students_and_Guardians_By_Household.report
@@ -33,6 +33,11 @@
     <format>Summary</format>
     <groupingsDown>
         <dateGranularity>Day</dateGranularity>
+        <field>ACCOUNT_ID</field>
+        <sortOrder>Desc</sortOrder>
+    </groupingsDown>
+    <groupingsDown>
+        <dateGranularity>Day</dateGranularity>
         <field>ACCOUNT.NAME</field>
         <sortOrder>Asc</sortOrder>
     </groupingsDown>
@@ -46,8 +51,6 @@
     <showDetails>true</showDetails>
     <showGrandTotal>false</showGrandTotal>
     <showSubTotals>false</showSubTotals>
-    <sortColumn>CONTACT_RECORDTYPE</sortColumn>
-    <sortOrder>Asc</sortOrder>
     <timeFrameFilter>
         <dateColumn>CREATED_DATE</dateColumn>
         <interval>INTERVAL_CUSTOM</interval>


### PR DESCRIPTION
# Critical Changes

# Changes
We've fixed a bug with the unmanaged report, "Students and Guardians by Household." This report was grouping Contacts by Account Name instead of Account ID, which could cause Contacts in different households to be grouped together in Household Accounts with the same name.

If you installed K-12 Architecture Kit before November 14th, 2019, you can manually modify the report to group Contacts by Account ID.

# Issues Closed
- Fixes: #135 
# New Metadata

# Deleted Metadata

# Testing Notes
