### PR TITLE
W-037412: [K12]: Add descriptions and update K12 cci flows

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -42,7 +42,7 @@ tasks:
             path: unpackaged/config/trial
 
     update_admin_profile:
-        description: Retrieves, edits, and redeploys the Admin.profile with full FLS perms for all objects/fields
+        #description: Retrieves, edits, and redeploys the Admin.profile with full FLS perms for all objects/fields
         class_path: tasks.salesforce.UpdateAdminProfile
 
     retrieve_postinstall_config:
@@ -62,7 +62,7 @@ tasks:
             namespace_tokenize: $project_config.project__package__namespace
 
     uninstall_packaged_incremental:
-        description: Deletes any metadata from the package in the target org not in the local workspace
+        #description: Deletes any metadata from the package in the target org not in the local workspace
         class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
         options:
             ignore:
@@ -85,7 +85,7 @@ tasks:
 
 flows:
     config_managed:
-        description: Configure an org for use as a dev org after package metadata is deployed
+        #description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             3:
                 task: deploy_k12_kit_settings
@@ -106,7 +106,7 @@ flows:
                 options:
                     unmanaged: False
     qa_org:
-        description: Set up an org as a QA environment for unmanaged metadata
+        #description: Set up an org as a QA environment for unmanaged metadata
         steps:
             4:
                 task: enable_course_connections
@@ -120,7 +120,7 @@ flows:
                 task: snapshot_changes
 
     dev_org:
-        description: Set up an org as a development environment for unmanaged metadata
+        #description: Set up an org as a development environment for unmanaged metadata
         steps:
             4:
                 task: enable_course_connections
@@ -134,7 +134,7 @@ flows:
                 task: snapshot_changes
 
     dev_org_namespaced:
-        description: Set up a namespaced scratch org as a development environment for unmanaged metadata
+        #description: Set up a namespaced scratch org as a development environment for unmanaged metadata
         steps:
             4:
                 task: enable_course_connections

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -42,6 +42,7 @@ tasks:
             path: unpackaged/config/trial
 
     update_admin_profile:
+        description: Retrieves, edits, and redeploys the Admin.profile with full FLS perms for all objects/fields
         class_path: tasks.salesforce.UpdateAdminProfile
 
     retrieve_postinstall_config:
@@ -61,6 +62,7 @@ tasks:
             namespace_tokenize: $project_config.project__package__namespace
 
     uninstall_packaged_incremental:
+        description: Deletes any metadata from the package in the target org not in the local workspace
         class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
         options:
             ignore:
@@ -73,7 +75,7 @@ tasks:
                     - NewNote
                     - NewTask
                     - SendEmail
-    
+
     execute_install_apex:
         description: Runs most of the install script methods from STG_InstallScript class
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
@@ -83,6 +85,7 @@ tasks:
 
 flows:
     config_managed:
+        description: Configure an org for use as a dev org after package metadata is deployed
         steps:
             3:
                 task: deploy_k12_kit_settings
@@ -104,6 +107,7 @@ flows:
                     unmanaged: False
 
     dev_org:
+        description: Set up an org as a development environment for unmanaged metadata
         steps:
             4:
                 task: enable_course_connections
@@ -115,6 +119,7 @@ flows:
                 task: execute_install_apex
 
     dev_org_namespaced:
+        description: Set up a namespaced scratch org as a development environment for unmanaged metadata
         steps:
             4:
                 task: enable_course_connections

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -105,6 +105,19 @@ flows:
                 task: deploy_trial_config
                 options:
                     unmanaged: False
+    qa_org:
+        description: Set up an org as a QA environment for unmanaged metadata
+        steps:
+            4:
+                task: enable_course_connections
+            5:
+                task: deploy_trial_config
+            6:
+                task: deploy_k12_kit_settings
+            7:
+                task: execute_install_apex
+            8:
+                task: snapshot_changes
 
     dev_org:
         description: Set up an org as a development environment for unmanaged metadata
@@ -114,9 +127,11 @@ flows:
             5:
                 task: deploy_trial_config
             6:
-                task: snapshot_changes
+                task: deploy_k12_kit_settings
             7:
                 task: execute_install_apex
+            8:
+                task: snapshot_changes
 
     dev_org_namespaced:
         description: Set up a namespaced scratch org as a development environment for unmanaged metadata
@@ -130,9 +145,11 @@ flows:
                 options:
                     namespaced_org: True
             6:
-                task: snapshot_changes
+                task: deploy_k12_kit_settings
             7:
                 task: execute_install_apex
+            8:
+                task: snapshot_changes
 
 plans:
     install:


### PR DESCRIPTION
# Critical Changes

# Changes
We are updating K12's Cumulus.yml file to ensure that each tasks and flows have descriptions. 

We have updated qa_org flow to ensure that it mimics dev_org flow so that QE team can use this flow when spinning up a testing org. 

We have updated dev_org and dev_org_namespaced flows to include deploy_k12_kit_settings task so that it defaults the org's Account model to Household. 

We have updated qa_org, dev_org, and dev_org_namespaced flow where snapshot_changes task is added as the last step for each flow. 

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
