### PR TITLE
Add K12 App tile to Launcher when installing from link

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -31,6 +31,15 @@ tasks:
             path: scripts/configure_k12_kit.cls
             apex: enableCourseConnections();
 
+    deploy_k12_app:
+        description: Deploys the K12 Kit App for those who use the installer rather than the trial
+        class_path: cumulusci.tasks.salesforce.Deploy
+        group: Project-specific
+        ui_options:
+            name: Deploy K12 Architecture Kit app tile
+        options:
+            path: unpackaged/config/installer
+
     deploy_trial_config:
         description: Deploys metadata and configuration for TSOs.
         class_path: cumulusci.tasks.salesforce.Deploy
@@ -186,6 +195,8 @@ plans:
                 ui_options:
                     config:
                         name: K-12 Architecture Kit Metadata and Configuration
+            5:
+                task: deploy_k12_app
 orgs:
     scratch:
         dev_namespaced:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -114,6 +114,7 @@ flows:
                 task: deploy_trial_config
                 options:
                     unmanaged: False
+                    
     qa_org:
         #description: Set up an org as a QA environment for unmanaged metadata
         steps:

--- a/unpackaged/config/installer/package.xml
+++ b/unpackaged/config/installer/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>Profile</name>
+    </types>
+    <version>45.0</version>
+</Package>

--- a/unpackaged/config/installer/profiles/Admin.profile
+++ b/unpackaged/config/installer/profiles/Admin.profile
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>K12Kit</application>
+        <default>true</default>
+        <visible>true</visible>
+    </applicationVisibilities>
+</Profile>


### PR DESCRIPTION
# Critical Changes

# Changes
- The K-12 Architecture Kit application tile is now visible from the App Launcher for users with the System Administrator profile when the K-12 Architecture Kit is installed with the installer link.

# Issues Closed
- Fixes: #142 
# New Metadata

# Deleted Metadata

# Testing Notes
- A new cci task has been created and added the the install plan in cci. However you cannot run plans so the steps to test in a local org are:

-- cci task run update_dependencies
-- cci task run deploy_pre -o unmanaged False
-- cci task run install_managed 
-- cci task run deploy_post -o unmanaged False
-- cci task run deploy_k12_app

After running these tasks against a fresh scratch org, you should see the K12 app has been added to the launcher.