### PR TITLE
Extend regression flow with trial and course connections

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -99,6 +99,13 @@ flows:
             3:
                 task: deploy_k12_kit_settings
 
+    config_regression:
+        steps:
+            2:
+                task: enable_course_connections
+            3:
+                task: deploy_trial_config
+
     trial_org:
         description: Deploy trial configuration to an org.
         steps:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -103,8 +103,12 @@ flows:
         steps:
             2:
                 task: enable_course_connections
+                options:
+                    managed: True
             3:
                 task: deploy_trial_config
+                options:
+                    unmanaged: False
 
     trial_org:
         description: Deploy trial configuration to an org.

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -101,14 +101,24 @@ flows:
 
     config_regression:
         steps:
+            1:
+                task: deploy_post
+                options:
+                    unmanaged: False
             2:
+                task: deploy_k12_kit_settings
+            3:
                 task: enable_course_connections
                 options:
                     managed: True
-            3:
+            4:
                 task: deploy_trial_config
                 options:
                     unmanaged: False
+            5:
+                task: update_admin_profile
+                options:
+                    managed: True
 
     trial_org:
         description: Deploy trial configuration to an org.


### PR DESCRIPTION
This PR adds `deploy_trial_config` and `enable_course_connections` tasks to `config_regression`.

----

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes

``` console
$ cci flow run regression_org --org release
```
