### PR TITLE
[K12] Expand automation documentation

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -19,7 +19,7 @@ tasks:
     deploy_k12_kit_settings:
         description: Configure the default K-12 Architecture Kit Settings
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
-        group: Project-specific
+        group: 'K-12: Custom Settings'
         options:
             path: scripts/configure_k12_kit.cls
             apex: initializeK12KitSettings();
@@ -27,7 +27,7 @@ tasks:
     enable_course_connections:
         description: Enables course connections and sets default record types
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
-        group: Project-specific
+        group: 'K-12: Custom Settings'
         options:
             path: scripts/configure_k12_kit.cls
             apex: enableCourseConnections();
@@ -35,7 +35,7 @@ tasks:
     deploy_k12_app:
         description: Deploys the K12 Kit App for those who use the installer rather than the trial
         class_path: cumulusci.tasks.salesforce.Deploy
-        group: Project-specific
+        group: 'K-12: Installer Tasks'
         ui_options:
             name: Deploy K12 Architecture Kit app tile
         options:
@@ -44,7 +44,7 @@ tasks:
     deploy_trial_config:
         description: Deploys metadata and configuration for TSOs.
         class_path: cumulusci.tasks.salesforce.Deploy
-        group: Project-specific
+        group: 'K-12: Trial'
         ui_options:
             name: Deploy Trial Metadata
         options:
@@ -74,7 +74,7 @@ tasks:
     add_picklist_values:
         description: Adds picklist values to the given field, if they don't already exist.
         class_path: tasks.add_picklist_values.AddPicklistValues
-        group: Custom Tasks
+        group: 'K-12: Metadata'
         
     uninstall_packaged_incremental:
         #description: Deletes any metadata from the package in the target org not in the local workspace
@@ -94,6 +94,7 @@ tasks:
     execute_install_apex:
         description: Runs most of the install script methods from STG_InstallScript class
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
+        group: 'K-12: Custom Settings'
         options:
             apex:
                 STG_InstallScript.setK12kitDefaultTriggerHandlers();
@@ -130,6 +131,7 @@ flows:
 
     trial_org:
         description: Deploy trial configuration to an org.
+        group: 'K-12: Trial'
         steps:
             1:
                 flow: dependencies

--- a/documentation/automation.md
+++ b/documentation/automation.md
@@ -1,4 +1,28 @@
 # K-12 Automation Inventory
+
+**Table of Contents**
+
+- [K-12 Automation Inventory](#k-12-automation-inventory)
+    - [Key Workflows](#key-workflows)
+    - [Unpackaged Metadata](#unpackaged-metadata)
+    - [Utility Tasks and Flows](#utility-tasks-and-flows)
+        - [`add_picklist_values`](#addpicklistvalues)
+            - [Basic Usage](#basic-usage)
+                - [Task Documentation](#task-documentation)
+            - [Examples](#examples)
+                - [Basic Example](#basic-example)
+                - [Basic Example With Sorting](#basic-example-with-sorting)
+                - [Basic Example With Other Last](#basic-example-with-other-last)
+                - [Including Record Types](#including-record-types)
+                - [Including Multiple Record Types](#including-multiple-record-types)
+                - [Adding Multiple Values](#adding-multiple-values)
+                - [Sorting Alphabetically, With Other Last](#sorting-alphabetically-with-other-last)
+            - [Limitations](#limitations)
+    - [Trialforce Source Org (TSO) Updates](#trialforce-source-org-tso-updates)
+        - [How is the TSO updated during a release?](#how-is-the-tso-updated-during-a-release)
+        - [How do I access the trial experience?](#how-do-i-access-the-trial-experience)
+        - [What needs to go in `unpackaged/config/trial` versus `unpackaged/{pre,post}`?](#what-needs-to-go-in-unpackagedconfigtrial-versus-unpackagedprepost)
+
 ## Key Workflows
 
 | Workflow                     | Flow                 | Org Type         | Managed | Namespace |

--- a/documentation/automation.md
+++ b/documentation/automation.md
@@ -1,8 +1,38 @@
-# K-12 Custom Task: add_picklist_values
+# K-12 Automation Inventory
+## Key Workflows
+
+| Workflow                     | Flow                 | Org Type         | Managed | Namespace |
+|------------------------------|----------------------|------------------|---------|-----------|
+| Development                  | `dev_org`            | `dev`            |         |           |
+| Development (Namespaced)     | `dev_org_namespaced` | `dev_namespaced` |         | ✔         |
+| QA                           | `qa_org`             | `dev`            |         |           |
+| Regression                   | `regression_org`     | `release`        | ✔       |           |
+| Latest Trial Template        | N/A                  | `trial`          | ✔       |           |
+| Update Trialforce Source Org | `trial_org`          | `release`        | ✔       |           |
+
+## Unpackaged Metadata
+
+Unpackaged directory structure:
+
+```
+unpackaged/config
+├── installer
+└── trial
+```
+
+Each directory is used as follows:
+
+| Directory          | Purpose                      | Deploy task           | Retrieve task |
+|--------------------|------------------------------|-----------------------|---------------|
+| `config/installer` | Sets `K12Kit` App as default | `deploy_k12_app`      |               |
+| `config/trial`     | Unmanaged TSO configuration  | `deploy_trial_config` |               |
+
+## Utility Tasks and Flows
+### `add_picklist_values`
 
 We’ve implemented a custom task in the K-12 Architecture Kit for adding new picklist values to an existing field. This use case is generic enough that this custom task may eventually move into core CumulusCI, but for now it resides in the K-12 repository.
 
-## Basic Usage
+#### Basic Usage
 
 Given an object with an existing picklist field, you can add one or several new picklist options to the field. They will be added to the end of the picklist, unless the picklist to be sorted alphabetically or we pass in the option to leave “Other” at the end.
 
@@ -13,7 +43,7 @@ If the customer already has a picklist option with the same name on the picklist
 **Validation:** If the object or field doesn’t exist, or the field exists but isn’t a picklist field, an error is thrown when running the task. Additionally, any record types that are specified that don’t exist or are not marked as active in the org are skipped.
 * * *
 
-### Task Documentation
+##### Task Documentation
 
 Task name: `add_picklist_values`
 Options:
@@ -37,9 +67,9 @@ cci task run add_picklist_values --org ORG
 
 Validation: `sorted` and `otherlast` cannot both be true in the same task execution, otherwise an error is thrown.
 
-## Examples
+#### Examples
 
-### Basic Example
+##### Basic Example
 
 This adds the “Has Single Parent” picklist option to the end of the Attribute Type picklist on the Attribute object in EDA.
 
@@ -50,7 +80,7 @@ cci task run add_picklist_values --org dev
     -o values "Has Single Parent"
 ```
 
-### Basic Example With Sorting
+##### Basic Example With Sorting
 
 This adds the “Has Single Parent” picklist option to the Attribute Type picklist on the Attribute object in EDA. When the user uses the dropdown in the UI, all of the values will appear alphabetically.
 
@@ -62,7 +92,7 @@ cci task run add_picklist_values --org dev
     -o sorted True
 ```
 
-### Basic Example With Other Last
+##### Basic Example With Other Last
 
 This adds the “Has Single Parent” picklist option to the end of the Attribute Type picklist on the Attribute object in EDA. If the Other option exists on the picklist field (which it does for Attribute Type unless the customer has removed it), Other will remain or be moved to the bottom of the picklist.
 
@@ -74,7 +104,7 @@ cci task run add_picklist_values --org dev
     -o otherlast True
 ```
 
-### Including Record Types
+##### Including Record Types
 
 This adds the “Has Single Parent” picklist option to the end of the Attribute Type picklist on the Attribute object in EDA. It is also made available to the Student Characteristic record type.
 
@@ -86,7 +116,7 @@ cci task run add_picklist_values --org dev
     -o recordtypes hed__Student_Characteristic
 ```
 
-### Including Multiple Record Types
+##### Including Multiple Record Types
 
 This adds the “Other” picklist option to the end of the Attribute Type picklist on the Attribute object in EDA. It is also made available to both the Student Characteristic and Credential record type.
 
@@ -98,7 +128,7 @@ cci task run add_picklist_values --org dev
     -o recordtypes hed__Student_Characteristic,hed__Credential
 ```
 
-### Adding Multiple Values
+##### Adding Multiple Values
 
 This adds the “2020”, “2021”, and “2022” picklist options to the end of the Year picklist on the custom Grants object.
 
@@ -109,7 +139,7 @@ cci task run add_picklist_values --org dev
     -o values "2020,2021,2022"
 ```
 
-### Sorting Alphabetically, With Other Last
+##### Sorting Alphabetically, With Other Last
 
 This is an interesting use case! This requires the task to be run twice.
 
@@ -131,7 +161,7 @@ cci task run add_picklist_values --org dev
     -o otherlast True
 ```
 
-## Limitations
+#### Limitations
 
 A few limitations exist in the current implementation of the task:
 
@@ -143,3 +173,36 @@ A few limitations exist in the current implementation of the task:
 * There is no way to specify a specific order for the existing or new values, except:
     * Sorting the entire picklist alphabetically
     * Adding the new values to the end (above the Other value, if applicable)
+
+## Trialforce Source Org (TSO) Updates
+
+K-12 is the first SFDO product to maintain its Trialforce Source Org (TSO) using CumulusCI automation. While defining the trial configuration via CCI makes it easier to keep the TSO up to date, it does add some complexity. This section provides some additional context on the process.
+
+### How is the TSO updated during a release?
+
+The basic process during each release:
+
+1. The TSO is updated using the `trial_org` flow, which:
+    1. Upgrades to the latest version of the EDA managed package and deploys pre-install (`dependencies`),
+    2. Installs the latest version of the K-12 managed package,
+    3. Deploys post-install metadata, sets admin permissions, and sets the `hed__Account_Processor__c` (`config_managed`)
+    4. Enables course connections, and
+    5. Deploys unmanaged trial metadata.
+2. A new Trialforce Template ID is generated,
+3. The `trial` scratch org definition file is updated with the latest template ID.
+
+### How do I access the trial experience?
+
+You have two options:
+
+1. To see what a trial org based on the current release's Trialforce Template ID, use the `trial` scratch org config (e.g. `cci org browser trial`).
+2. To see the output of the `trial_org` flow that is run aginst the TSO, use the `trial_org` flow and the `release` scratch org config (e.g. `cci flow run trial_org --org release`).
+
+### What needs to go in `unpackaged/config/trial` versus `unpackaged/{pre,post}`?
+
+The short answer, two kinds of metadata go in `unpackaged/config/trial`:
+
+1. **Managed components that aren't upgradeable.** Example: Adding a picklist value to a `CustomField`. We don't need to include it in pre/post-install config since we're assuming that the newly added value will be included as part of the installation.
+2. **Unmanaged components that are trial-only.** Example: A custom report that is intended for the TSO only.
+
+It isn't necessary to include things in both `unpackaged/config/trial` and `unpackaged/{pre,post}` folders, as the latter are run against the TSO at each release. 

--- a/documentation/automation.md
+++ b/documentation/automation.md
@@ -219,7 +219,7 @@ The basic process during each release:
 
 You have two options:
 
-1. To see what a trial org based on the current release's Trialforce Template ID, use the `trial` scratch org config (e.g. `cci org browser trial`).
+1. To see a trial org based on the current release's Trialforce Template ID, use the `trial` scratch org config (e.g. `cci org browser trial`).
 2. To see the output of the `trial_org` flow that is run aginst the TSO, use the `trial_org` flow and the `release` scratch org config (e.g. `cci flow run trial_org --org release`).
 
 ### What needs to go in `unpackaged/config/trial` versus `unpackaged/{pre,post}`?


### PR DESCRIPTION
This PR adds some detail to the existing docs to address the TSO process, as well as list workflows and their corresponding CCI tasks/flows. In addition, task/flow group names have been updated to add the `K12` prefix to make them easier to spot.


----

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes