### PR TITLE
[K12] Enable Application's Tab by Default in K12 For Admin Profile Only

### DIFF
--- a/unpackaged/config/installer/profiles/Admin.profile
+++ b/unpackaged/config/installer/profiles/Admin.profile
@@ -5,4 +5,8 @@
         <default>true</default>
         <visible>true</visible>
     </applicationVisibilities>
+    <tabVisibilities>
+        <tab>hed__Application__c</tab>
+        <visibility>DefaultOn</visibility>
+    </tabVisibilities>
 </Profile>

--- a/unpackaged/config/trial/profiles/Admin.profile
+++ b/unpackaged/config/trial/profiles/Admin.profile
@@ -113,4 +113,8 @@
     <layoutAssignments>
         <layout>hed__Time_Block__c-%%%NAMESPACE%%%K12 Kit Time Block Layout</layout>
     </layoutAssignments>
+    <tabVisibilities>
+        <tab>hed__Application__c</tab>
+        <visibility>DefaultOn</visibility>
+    </tabVisibilities>
 </Profile>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
- Run "cci org scratch trial" 
- Run "cci flow run trial_org" 
- Open trial scratch org
 (1) Click on the pencil 
 (2) Select "Add more items"
 (3) Select "All"
 (4) Search for Applications and you should be able to see the tab option to add 