### PR TITLE
K12 Update the Exit Reason picklist value to "No-Show" on Grade Enrollment

### DIFF
--- a/src/objects/Grade_Enrollment__c.object
+++ b/src/objects/Grade_Enrollment__c.object
@@ -160,7 +160,7 @@
                 <value>
                     <fullName>No Show</fullName>
                     <default>false</default>
-                    <label>No Show</label>
+                    <label>No-Show</label>
                 </value>
                 <value>
                     <fullName>Promoted</fullName>

--- a/unpackaged/config/trial/objects/___NAMESPACE___Grade_Enrollment__c.object
+++ b/unpackaged/config/trial/objects/___NAMESPACE___Grade_Enrollment__c.object
@@ -126,7 +126,7 @@
                 <value>
                     <fullName>No Show</fullName>
                     <default>false</default>
-                    <label>No Show</label>
+                    <label>No-Show</label>
                 </value>
                 <value>
                     <fullName>Promoted</fullName>


### PR DESCRIPTION
# Critical Changes

# Changes
We have updated the Grade Enrollment Exist Reason picklist value from "No Show" to "No-Show."
New customers will automatically get this updated value; we recommend that existing customers update the picklist label manually. 

# Issues Closed
Closes #173
# New Metadata

# Deleted Metadata

# Testing Notes
Trial org:
- Run cci org scratch trial 
- Run cci flow run trial_org 
- Ensure that "No-Show" is showing as the picklist value for Exist Reason on Grade Enrollment. 

Non trial org:
- Run cci org scratch dev
- Run cci flow dev_org 
- Ensure that "No-Show" is showing as the picklist value for Exist Reason on Grade Enrollment. 