### PR TITLE
[K-12] Tracking School Days Missed on Behavior Response

### DIFF
--- a/src/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
+++ b/src/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
@@ -41,6 +41,10 @@
                 <behavior>Edit</behavior>
                 <field>hed__End_Date__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>School_Days_Missed__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>

--- a/src/objectTranslations/hed__Behavior_Response__c-ca.objectTranslation
+++ b/src/objectTranslations/hed__Behavior_Response__c-ca.objectTranslation
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">  
+    <fields>
+        <help><!-- The length, in school days, of the response. --></help>
+        <label><!-- School Days Missed --></label>
+        <name>School_Days_Missed__c</name>
+    </fields>
+</CustomObjectTranslation>

--- a/src/objectTranslations/hed__Behavior_Response__c-en_US.objectTranslation
+++ b/src/objectTranslations/hed__Behavior_Response__c-en_US.objectTranslation
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help><!-- The length, in school days, of the response. --></help>
+        <label><!-- School Days Missed --></label>
+        <name>School_Days_Missed__c</name>
+    </fields>
+</CustomObjectTranslation>

--- a/src/objectTranslations/hed__Behavior_Response__c-es.objectTranslation
+++ b/src/objectTranslations/hed__Behavior_Response__c-es.objectTranslation
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help><!-- The length, in school days, of the response. --></help>
+        <label><!-- School Days Missed --></label>
+        <name>School_Days_Missed__c</name>
+    </fields>
+</CustomObjectTranslation>

--- a/src/objectTranslations/hed__Behavior_Response__c-fr.objectTranslation
+++ b/src/objectTranslations/hed__Behavior_Response__c-fr.objectTranslation
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <help><!-- The length, in school days, of the response. --></help>
+        <label><!-- School Days Missed --></label>
+        <name>School_Days_Missed__c</name>
+    </fields>
+</CustomObjectTranslation>

--- a/src/objects/hed__Behavior_Response__c.object
+++ b/src/objects/hed__Behavior_Response__c.object
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fields>
+        <fullName>School_Days_Missed__c</fullName>
+        <description>The length, in school days, of the response.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The length, in school days, of the response.</inlineHelpText>
+        <label>School Days Missed</label>
+        <precision>5</precision>
+        <required>false</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
+</CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -39,6 +39,7 @@
         <members>Grade_Enrollment__c.Status__c</members>
         <members>Grade_Enrollment__c.Term__c</members>
         <members>hed__Attribute__c.Grade_Level__c</members>
+        <members>hed__Behavior_Response__c.School_Days_Missed__c</members>
         <members>hed__Relationship__c.FERPA_Approved__c</members>
         <members>hed__Relationship__c.HIPPA_Approved__c</members>
         <name>CustomField</name>

--- a/src/package.xml
+++ b/src/package.xml
@@ -71,6 +71,10 @@
         <members>hed__Attribute__c-en_US</members>
         <members>hed__Attribute__c-es</members>
         <members>hed__Attribute__c-fr</members>
+        <members>hed__Behavior_Response__c-ca</members>
+        <members>hed__Behavior_Response__c-en_US</members>
+        <members>hed__Behavior_Response__c-es</members>
+        <members>hed__Behavior_Response__c-fr</members>
         <members>hed__Relationship__c-ca</members>
         <members>hed__Relationship__c-en_US</members>
         <members>hed__Relationship__c-es</members>

--- a/unpackaged/config/trial/objects/hed__Behavior_Response__c.object
+++ b/unpackaged/config/trial/objects/hed__Behavior_Response__c.object
@@ -29,4 +29,17 @@
     </nameField>
     <pluralLabel>Behavior Responses</pluralLabel>
     <sharingModel>ReadWrite</sharingModel>
+    <fields>
+        <fullName>School_Days_Missed__c</fullName>
+        <description>The length, in school days, of the response.</description>
+        <externalId>false</externalId>
+        <inlineHelpText>The length, in school days, of the response.</inlineHelpText>
+        <label>School Days Missed</label>
+        <precision>5</precision>
+        <required>false</required>
+        <scale>2</scale>
+        <trackTrending>false</trackTrending>
+        <type>Number</type>
+        <unique>false</unique>
+    </fields>
 </CustomObject>


### PR DESCRIPTION
# Critical Changes

# Changes
## Updates to Behavior Response
You can now track the number of days a student misses school in response to a Behavior Incident. For new customers, the "School Days Missed" field is automatically added to the Behavior Response page layout. Existing customers can add it to page layouts manually. See [Display a New Custom Object After a Product Release](https://powerofus.force.com/s/article/EDA-Display-Cust-Obj-Post-Rel).

# Issues Closed
Closes #184 

# New Metadata
School_Days_Missed__c

# Deleted Metadata

# Testing Notes
The field 'School Days Missed' should be visible on the page layout and should be defined as per the SPEC https://salesforce.quip.com/wtXAAIfa4mmZ#DJBACAxyxmZ.

The changes for TSO should be tested after the merge to Master.
