### PR TITLE
[K12] Picklist Updates to Case(Behavior Involvement) and Behavior Response Objects

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -106,10 +106,9 @@ tasks:
         class_path: tasks.add_picklist_values.AddPicklistValues
         group: 'K-12: Metadata'
         options:
-            sobject: hed__Case
+            sobject: Case
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
-            sorted: true
             recordtypes: Incident
             restricted: true
             
@@ -145,7 +144,7 @@ flows:
 
     config_regression:
         steps:
-            1: 
+            1:
                 flow: None
             2:
                 task: deploy_post
@@ -167,10 +166,18 @@ flows:
                     managed: True
             7:
                 task: add_application_type_picklist_values
-            8: 
+            8:
                 task: add_behavior_response_type_values
-            9: 
+                options:
+                    sorted: True
+            9:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
+                options:
+                    otherlast: True
+            10:
                 task: add_case_location_values
+                options:
+                    sorted: True
 
     trial_org:
         description: Deploy trial configuration to an org.
@@ -190,11 +197,19 @@ flows:
                     unmanaged: False
             6:
                 task: add_application_type_picklist_values
-            7: 
+            7:
                 task: add_behavior_response_type_values
-            8: 
-                task: add_case_location_values   
-            
+                options:
+                    sorted: True
+            8:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
+                options:
+                    otherlast: True
+            9:
+                task: add_case_location_values
+                options:
+                    sorted: True
+
     qa_org:
         #description: Set up an org as a QA environment for unmanaged metadata
         steps:
@@ -206,19 +221,21 @@ flows:
                 task: deploy_k12_kit_settings
             7:
                 task: add_application_type_picklist_values
-            8: 
+            8:
                 task: add_behavior_response_type_values
                 options:
                     sorted: True
-            9:                 
-                task: add_behavior_response_type_values
+            9:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
                 options:
                     otherlast: True
-            # 9: 
-            #     task: add_case_location_values
             10:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    sorted: True
             11:
+                task: execute_install_apex
+            12:
                 task: snapshot_changes
 
     dev_org:
@@ -230,15 +247,23 @@ flows:
                 task: deploy_trial_config
             6:
                 task: deploy_k12_kit_settings
-            7:  
+            7:
                 task: add_application_type_picklist_values
-            8: 
+            8:
                 task: add_behavior_response_type_values
-            9: 
-                task: add_case_location_values
+                options:
+                    sorted: True
+            9:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
+                options:
+                    otherlast: True
             10:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    sorted: True
             11:
+                task: execute_install_apex
+            12:
                 task: snapshot_changes
 
     dev_org_namespaced:
@@ -256,13 +281,21 @@ flows:
                 task: deploy_k12_kit_settings
             7:
                 task: add_application_type_picklist_values
-            8: 
+            8:
                 task: add_behavior_response_type_values
-            9: 
-                task: add_case_location_values
+                options:
+                    sorted: True
+            9:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
+                options:
+                    otherlast: True
             10:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    sorted: True
             11:
+                task: execute_install_apex
+            12:
                 task: snapshot_changes
 
     upgraded_org:
@@ -300,10 +333,18 @@ flows:
                     unmanaged: False
             6:
                 task: add_application_type_picklist_values
-            7: 
+            7:
                 task: add_behavior_response_type_values
-            8: 
+                options:
+                    sorted: True
+            8:
+                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
+                options:
+                    otherlast: True
+            9:
                 task: add_case_location_values
+                options:
+                    sorted: True
 
     ci_feature_beta_deps:
         description: When run, the latest version (including betas) of Cumulus and EDA are installed, and all tests are run.

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -110,8 +110,8 @@ tasks:
         options:
             sobject: Case
             field: hed__Location__c
-            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus, On Campus, Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School,Other"
-            existing_values: "Off Campus, On Campus, Other"
+            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus,On Campus,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
+            existing_values: "Off Campus, On Campus"
             recordtypes: Incident
             restricted: true
             sorted: True

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -109,7 +109,7 @@ tasks:
             sobject: Case
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
-            recordtypes: Incident
+            #recordtypes: Incident
             restricted: true
             
     uninstall_packaged_incremental:
@@ -178,6 +178,15 @@ flows:
                 task: add_case_location_values
                 options:
                     sorted: True
+            11:
+                task: add_case_location_values
+                options:
+                    otherlast: True
+            12:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
 
     trial_org:
         description: Deploy trial configuration to an org.
@@ -209,6 +218,15 @@ flows:
                 task: add_case_location_values
                 options:
                     sorted: True
+            10:
+                task: add_case_location_values
+                options:
+                    otherlast: True
+            11:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
 
     qa_org:
         #description: Set up an org as a QA environment for unmanaged metadata
@@ -234,8 +252,17 @@ flows:
                 options:
                     sorted: True
             11:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    otherlast: True
             12:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
+            13:
+                task: execute_install_apex
+            14:
                 task: snapshot_changes
 
     dev_org:
@@ -262,8 +289,17 @@ flows:
                 options:
                     sorted: True
             11:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    otherlast: True
             12:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
+            13:
+                task: execute_install_apex
+            14:
                 task: snapshot_changes
 
     dev_org_namespaced:
@@ -294,8 +330,17 @@ flows:
                 options:
                     sorted: True
             11:
-                task: execute_install_apex
+                task: add_case_location_values
+                options:
+                    otherlast: True
             12:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
+            13:
+                task: execute_install_apex
+            14:
                 task: snapshot_changes
 
     upgraded_org:
@@ -345,6 +390,15 @@ flows:
                 task: add_case_location_values
                 options:
                     sorted: True
+            10:
+                task: add_case_location_values
+                options:
+                    otherlast: True
+            11:
+                task: add_case_location_values
+                options: 
+                    recordtypes: Incident
+                    otherlast: True
 
     ci_feature_beta_deps:
         description: When run, the latest version (including betas) of Cumulus and EDA are installed, and all tests are run.

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -90,6 +90,7 @@ tasks:
             sobject: hed__Application__c
             field: hed__Application_Type__c
             values: "Elementary School,Middle School,High School"
+            #existing_values: "Elementary School,Middle School,High School"
             sorted: true
     
     add_behavior_response_type_values:
@@ -99,7 +100,7 @@ tasks:
         options:
             sobject: hed__Behavior_Response__c
             field: hed__Type__c
-            values: "Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
+            values: "Detention,Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
             restricted: true
             sorted: True
     

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -80,6 +80,7 @@ tasks:
         description: Adds picklist values to the given field, if they don't already exist.
         class_path: tasks.add_picklist_values.AddPicklistValues
         group: 'K-12: Metadata'
+        namespaced: False
         
 
     add_application_type_picklist_values:
@@ -90,9 +91,10 @@ tasks:
             sobject: hed__Application__c
             field: hed__Application_Type__c
             values: "Elementary School,Middle School,High School"
-            #existing_values: "Elementary School,Middle School,High School"
+            existing_values: "Elementary School,Middle School,High School"
             sorted: true
-    
+            namespaced: False
+
     add_behavior_response_type_values:
         description: Adds additional picklist values to the Type field.
         class_path: tasks.add_picklist_values.AddPicklistValues
@@ -103,6 +105,8 @@ tasks:
             values: "Detention,Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
             restricted: true
             sorted: True
+            namespaced: False
+
     
     add_case_location_values: 
         description: Adds additional picklist values to the Location field.
@@ -116,7 +120,8 @@ tasks:
             recordtypes: Incident
             restricted: true
             sorted: True
-            
+            namespaced: False
+
     uninstall_packaged_incremental:
         #description: Deletes any metadata from the package in the target org not in the local workspace
         class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
@@ -259,6 +264,9 @@ flows:
                 task: add_behavior_response_type_values
             9:
                 task: add_case_location_values
+                options:
+                    namespaced: True
+                    namespace_value: 'hed'
             10:
                 task: execute_install_apex
             11:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -110,8 +110,8 @@ tasks:
         options:
             sobject: Case
             field: hed__Location__c
-            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus, On Campus, Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
-            existing_values: "Off Campus, On Campus"
+            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus, On Campus, Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School,Other"
+            existing_values: "Off Campus, On Campus, Other"
             recordtypes: Incident
             restricted: true
             sorted: True

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -111,6 +111,7 @@ tasks:
             sobject: Case
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus, On Campus, Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
+            existing_values: "Off Campus, On Campus"
             recordtypes: Incident
             restricted: true
             sorted: True

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -260,13 +260,16 @@ flows:
                 task: deploy_k12_kit_settings
             7:
                 task: add_application_type_picklist_values
+                options:
+                    namespaced: True
             8:
                 task: add_behavior_response_type_values
+                options:
+                    namespaced: True
             9:
                 task: add_case_location_values
                 options:
                     namespaced: True
-                    namespace_value: 'hed'
             10:
                 task: execute_install_apex
             11:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -123,7 +123,7 @@ tasks:
             namespaced: False
 
     uninstall_packaged_incremental:
-        #description: Deletes any metadata from the package in the target org not in the local workspace
+        description: Deletes any metadata from the package in the target org not in the local workspace
         class_path: cumulusci.tasks.salesforce.UninstallPackagedIncremental
         options:
             ignore:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -110,7 +110,7 @@ tasks:
         options:
             sobject: Case
             field: hed__Location__c
-            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
+            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus, On Campus, Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
             recordtypes: Incident
             restricted: true
             sorted: True

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -80,6 +80,7 @@ tasks:
         description: Adds picklist values to the given field, if they don't already exist.
         class_path: tasks.add_picklist_values.AddPicklistValues
         group: 'K-12: Metadata'
+        
 
     add_application_type_picklist_values:
         description: Adds Elementary School, Middle School, and High School picklist values to the application type field.
@@ -100,6 +101,7 @@ tasks:
             field: hed__Type__c
             values: "Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
             restricted: true
+            sorted: True
     
     add_case_location_values: 
         description: Adds additional picklist values to the Location field.
@@ -109,8 +111,9 @@ tasks:
             sobject: Case
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
-            #recordtypes: Incident
+            recordtypes: Incident
             restricted: true
+            sorted: True
             
     uninstall_packaged_incremental:
         #description: Deletes any metadata from the package in the target org not in the local workspace
@@ -168,25 +171,9 @@ flows:
                 task: add_application_type_picklist_values
             8:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             9:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
-            10:
                 task: add_case_location_values
-                options:
-                    sorted: True
-            11:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            12:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
+
 
     trial_org:
         description: Deploy trial configuration to an org.
@@ -208,25 +195,8 @@ flows:
                 task: add_application_type_picklist_values
             7:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             8:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
-            9:
                 task: add_case_location_values
-                options:
-                    sorted: True
-            10:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            11:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
 
     qa_org:
         #description: Set up an org as a QA environment for unmanaged metadata
@@ -241,28 +211,11 @@ flows:
                 task: add_application_type_picklist_values
             8:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             9:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
+                task: add_case_location_values
             10:
-                task: add_case_location_values
-                options:
-                    sorted: True
-            11:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            12:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
-            13:
                 task: execute_install_apex
-            14:
+            11:
                 task: snapshot_changes
 
     dev_org:
@@ -278,28 +231,11 @@ flows:
                 task: add_application_type_picklist_values
             8:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             9:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
+                task: add_case_location_values
             10:
-                task: add_case_location_values
-                options:
-                    sorted: True
-            11:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            12:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
-            13:
                 task: execute_install_apex
-            14:
+            11:
                 task: snapshot_changes
 
     dev_org_namespaced:
@@ -319,28 +255,11 @@ flows:
                 task: add_application_type_picklist_values
             8:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             9:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
+                task: add_case_location_values
             10:
-                task: add_case_location_values
-                options:
-                    sorted: True
-            11:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            12:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
-            13:
                 task: execute_install_apex
-            14:
+            11:
                 task: snapshot_changes
 
     upgraded_org:
@@ -380,25 +299,8 @@ flows:
                 task: add_application_type_picklist_values
             7:
                 task: add_behavior_response_type_values
-                options:
-                    sorted: True
             8:
-                task: add_behavior_response_type_values # intentionally called twice to allow for sorting and other value as last option
-                options:
-                    otherlast: True
-            9:
                 task: add_case_location_values
-                options:
-                    sorted: True
-            10:
-                task: add_case_location_values
-                options:
-                    otherlast: True
-            11:
-                task: add_case_location_values
-                options: 
-                    recordtypes: Incident
-                    otherlast: True
 
     ci_feature_beta_deps:
         description: When run, the latest version (including betas) of Cumulus and EDA are installed, and all tests are run.

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -91,6 +91,29 @@ tasks:
             field: hed__Application_Type__c
             values: "Elementary School,Middle School,High School"
             sorted: true
+    
+    add_behavior_response_type_values:
+        description: Adds additional picklist values to the Type field.
+        class_path: tasks.add_picklist_values.AddPicklistValues
+        group: 'K-12: Metadata'
+        options:
+            sobject: hed__Behavior_Response__c
+            field: hed__Type__c
+            values: "Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
+            sorted: true
+            otherlast: true
+    
+    add_case_location_values: 
+        description: Adds additional picklist values to the Location field.
+        class_path: tasks.add_picklist_values.AddPicklistValues
+        group: 'K-12: Metadata'
+        options:
+            sobject: hed__Case
+            field: hed__Location__c
+            values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
+            sorted: true
+            otherlast: true
+            recordtypes: hed__Incident
             
     uninstall_packaged_incremental:
         #description: Deletes any metadata from the package in the target org not in the local workspace
@@ -146,6 +169,10 @@ flows:
                     managed: True
             7:
                 task: add_application_type_picklist_values
+            8: 
+                task: add_behavior_response_type_values
+            9: 
+                task: add_case_location_values
 
     trial_org:
         description: Deploy trial configuration to an org.
@@ -165,7 +192,11 @@ flows:
                     unmanaged: False
             6:
                 task: add_application_type_picklist_values
-                    
+            7: 
+                task: add_behavior_response_type_values
+            8: 
+                task: add_case_location_values   
+            
     qa_org:
         #description: Set up an org as a QA environment for unmanaged metadata
         steps:
@@ -177,9 +208,13 @@ flows:
                 task: deploy_k12_kit_settings
             7:
                 task: add_application_type_picklist_values
-            8:
+            8: 
+                task: add_behavior_response_type_values
+            9: 
+                task: add_case_location_values
+            10:
                 task: execute_install_apex
-            9:
+            11:
                 task: snapshot_changes
 
     dev_org:
@@ -193,9 +228,13 @@ flows:
                 task: deploy_k12_kit_settings
             7:  
                 task: add_application_type_picklist_values
-            8:
+            8: 
+                task: add_behavior_response_type_values
+            9: 
+                task: add_case_location_values
+            10:
                 task: execute_install_apex
-            9:
+            11:
                 task: snapshot_changes
 
     dev_org_namespaced:
@@ -213,9 +252,13 @@ flows:
                 task: deploy_k12_kit_settings
             7:
                 task: add_application_type_picklist_values
-            8:
+            8: 
+                task: add_behavior_response_type_values
+            9: 
+                task: add_case_location_values
+            10:
                 task: execute_install_apex
-            9:
+            11:
                 task: snapshot_changes
 
     upgraded_org:
@@ -235,6 +278,10 @@ flows:
                 task: install_managed_beta
             6:
                 task: add_application_type_picklist_values
+            7: 
+                task: add_behavior_response_type_values
+            8: 
+                task: add_case_location_values
 
     ci_feature_beta_deps:
         description: When run, the latest version (including betas) of Cumulus and EDA are installed, and all tests are run.

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -99,8 +99,7 @@ tasks:
             sobject: hed__Behavior_Response__c
             field: hed__Type__c
             values: "Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
-            sorted: true
-            otherlast: true
+            restricted: true
     
     add_case_location_values: 
         description: Adds additional picklist values to the Location field.
@@ -111,8 +110,8 @@ tasks:
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
             sorted: true
-            otherlast: true
-            recordtypes: hed__Incident
+            recordtypes: Incident
+            restricted: true
             
     uninstall_packaged_incremental:
         #description: Deletes any metadata from the package in the target org not in the local workspace
@@ -209,8 +208,14 @@ flows:
                 task: add_application_type_picklist_values
             8: 
                 task: add_behavior_response_type_values
-            9: 
-                task: add_case_location_values
+                options:
+                    sorted: True
+            9:                 
+                task: add_behavior_response_type_values
+                options:
+                    otherlast: True
+            # 9: 
+            #     task: add_case_location_values
             10:
                 task: execute_install_apex
             11:

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -36,6 +36,7 @@ object_template = """<?xml version="1.0" encoding="UTF-8"?>
         <label>{label}</label>
         <type>Picklist</type>
         <valueSet>
+            <restricted>{restricted}</restricted>
             <valueSetDefinition>
                 <sorted>{sorted}</sorted>{picklist_values}
             </valueSetDefinition>
@@ -67,16 +68,14 @@ record_type_picklist_value_template = """
                 <default>{default}</default>
             </values>"""
 
+
 class AddPicklistValues(BaseSalesforceApiTask, Deploy):
     task_options = {
         "sobject": {
             "description": "SObject of the picklist field being modified",
             "required": True,
         },
-        "field": {
-            "description": "The picklist field being modified",
-            "required": True,
-        },
+        "field": {"description": "The picklist field being modified", "required": True},
         "values": {
             "description": "A comma-delimited list of the picklist values being added",
             "required": True,
@@ -92,20 +91,37 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         "otherlast": {
             "description": "If true, the Other value (if one exists) will remain at the end of the values",
             "required": False,
-        }
+        },
+        "restricted": {
+            "description": "If picklist value is a required field",
+            "required": False,
+        },
+        "buisness_process": {
+            "description": "If picklist value is a business_process",
+            "required": False,
+        },
     }
 
     def _init_options(self, kwargs):
         super()._init_options(kwargs)
         self.options["values"] = process_list_arg(self.options.get("values", []))
-        self.options["recordtypes"] = process_list_arg(self.options.get("recordtypes", []))
+        self.options["recordtypes"] = process_list_arg(
+            self.options.get("recordtypes", [])
+        )
+        self.options["restricted"] = process_bool_arg(
+            self.options.get("restricted", False)
+        )
         self.options["sorted"] = process_bool_arg(self.options.get("sorted", False))
-        self.options["otherlast"] = process_bool_arg(self.options.get("otherlast", False))
+        self.options["otherlast"] = process_bool_arg(
+            self.options.get("otherlast", False)
+        )
 
         if self.options["sorted"] and self.options["otherlast"]:
-            raise TaskOptionsError(f"The sorted option and otherlast option cannot both be set to true. "
-            "To sort a picklist but leave Other at the end, run the task twice: once to add the new values, sorted alphabetically, "
-            "and again to set Other at the end.")
+            raise TaskOptionsError(
+                f"The sorted option and otherlast option cannot both be set to true. "
+                "To sort a picklist but leave Other at the end, run the task twice: once to add the new values, sorted alphabetically, "
+                "and again to set Other at the end."
+            )
 
     # Adds picklist values to the given field, if they don't already exist.
     # Optionally adds the picklist values for the specified record types, if the record types exist.
@@ -117,17 +133,15 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
 
         # The Tooling API does not have the namespace or the '__c' suffix in the DeveloperName of the CustomField object
         # or in the DeveloperName of the EntityDefinition object, so we have to remove it.
-        split_field = field.split('__')
+        split_field = field.split("__")
         if len(split_field) == 3:
             field_developer_name = split_field[1]
-            field_namespace_query = "NamespacePrefix = '{}' AND ".format(
-                split_field[0]
-            )
+            field_namespace_query = "NamespacePrefix = '{}' AND ".format(split_field[0])
         else:
             field_developer_name = split_field[0]
             field_namespace_query = "NamespacePrefix = '' AND "
 
-        split_sobject = sobject.split('__')
+        split_sobject = sobject.split("__")
         if len(split_sobject) == 3:
             # Namespaced Custom Object
             sobject_developer_name = split_sobject[1]
@@ -144,8 +158,7 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             "FROM EntityDefinition "
             "WHERE {namespace_query}"
             "DeveloperName = '{sobject}'".format(
-                namespace_query=sobject_namespace_query,
-                sobject=sobject_developer_name
+                namespace_query=sobject_namespace_query, sobject=sobject_developer_name
             )
         )
 
@@ -162,7 +175,7 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             "AND TableEnumOrId = '{sobject_id}'".format(
                 namespace_query=field_namespace_query,
                 developer_name=field_developer_name,
-                sobject_id=validated_sobject_id
+                sobject_id=validated_sobject_id,
             )
         )
 
@@ -177,9 +190,13 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
 
         if validated_field["type"] == "Picklist":
             if validated_field["valueSet"]["valueSetDefinition"] != None:
-                existing_picklist_values = validated_field["valueSet"]["valueSetDefinition"]["value"]
+                existing_picklist_values = validated_field["valueSet"][
+                    "valueSetDefinition"
+                ]["value"]
             else:
-                raise Exception(f"Picklist fields that use Global Value Sets are not currently supported.")
+                raise Exception(
+                    f"Picklist fields that use Global Value Sets are not currently supported."
+                )
         else:
             raise Exception(f"{field} field is not a picklist field")
 
@@ -187,7 +204,9 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         package_xml = self._build_package_xml(picklist_record_types, sobject, field)
 
         # build the object XML:
-        object_xml = self._build_object_xml(validated_field, picklist_record_types, existing_picklist_values, field)
+        object_xml = self._build_object_xml(
+            validated_field, picklist_record_types, existing_picklist_values, field
+        )
 
         # create temporary files & deploy back to Salesforce
         with tempfile.TemporaryDirectory() as self.tempdir:
@@ -197,7 +216,8 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
 
             os.mkdir("{}/{}".format(self.tempdir, "objects"))
             object_xml_file = os.path.join(
-                self.tempdir, "objects", "{}.object".format(sobject))
+                self.tempdir, "objects", "{}.object".format(sobject)
+            )
             with open(object_xml_file, "w") as f:
                 f.write(object_xml)
 
@@ -215,12 +235,16 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             )
 
             active_record_types = [
-                rt for rt in record_type_tooling_results["records"] if rt["Metadata"]["active"] is True
+                rt
+                for rt in record_type_tooling_results["records"]
+                if rt["Metadata"]["active"] is True
             ]
 
             # validate against active_record_types
             for active_record_type in active_record_types:
-                record_type_name = active_record_type["FullName"].split('.')[1] # removes the SObject from FullName
+                record_type_name = active_record_type["FullName"].split(".")[
+                    1
+                ]  # removes the SObject from FullName
                 if record_type_name in self.options["recordtypes"]:
                     picklist_record_types.append(active_record_type)
                     picklist_record_type_names.append(record_type_name)
@@ -228,7 +252,9 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             for rt in self.options["recordtypes"]:
                 if rt not in picklist_record_type_names:
                     # Choosing to not throw an exception here since a customer might have deactivated or deleted a record type.
-                    self.logger.info(f"{rt} is not an active record type for the {sobject} object. Skipping over...")
+                    self.logger.info(
+                        f"{rt} is not an active record type for the {sobject} object. Skipping over..."
+                    )
 
         return picklist_record_types
 
@@ -239,21 +265,25 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             package_xml_record_types = ""
             for rt in picklist_record_types:
                 package_xml_record_types += package_xml_record_type_template.format(
-                    record_type_full_name = rt["FullName"]
+                    record_type_full_name=rt["FullName"]
                 )
-            
-            package_xml_record_types_block = package_xml_record_types_block_template.format(record_types = package_xml_record_types)
+
+            package_xml_record_types_block = package_xml_record_types_block_template.format(
+                record_types=package_xml_record_types
+            )
 
         # combine it all together
         package_xml = package_xml_template.format(
-            object = sobject, 
-            field = field, 
-            record_types_block = package_xml_record_types_block
+            object=sobject,
+            field=field,
+            record_types_block=package_xml_record_types_block,
         )
 
         return package_xml
 
-    def _build_object_xml(self, validated_field, picklist_record_types, existing_picklist_values, field):
+    def _build_object_xml(
+        self, validated_field, picklist_record_types, existing_picklist_values, field
+    ):
         picklist_values_xml = ""
         record_type_picklist_xml = ""
         other_picklist_xml = ""
@@ -264,31 +294,34 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         for existing_picklist_value in existing_picklist_values:
             values_added.append(existing_picklist_value["label"].lower())
             # if it exists, should "Other" remain at the bottom of the picklist?
-            if existing_picklist_value["label"] == "Other" and self.options["otherlast"]:
+            if (
+                existing_picklist_value["label"] == "Other"
+                and self.options["otherlast"]
+            ):
                 other_picklist_xml = picklist_value_template.format(
-                    name = existing_picklist_value["valueName"], 
-                    default = existing_picklist_value["default"], 
-                    label = existing_picklist_value["label"]
+                    name=existing_picklist_value["valueName"],
+                    default=existing_picklist_value["default"],
+                    label=existing_picklist_value["label"],
                 )
-            
+
             else:
                 picklist_values_xml += picklist_value_template.format(
-                    name = escape(existing_picklist_value["valueName"]), 
-                    default = existing_picklist_value["default"], 
-                    label = escape(existing_picklist_value["label"])
+                    name=escape(existing_picklist_value["valueName"]),
+                    default=existing_picklist_value["default"],
+                    label=escape(existing_picklist_value["label"]),
                 )
-        
+
         # add the new picklist values
         for value in self.options["values"]:
             # ignore any existing picklist values
             if value.lower() in values_added:
-                self.logger.info(f"{value} is already a picklist value on {field}. Skipping over...")
+                self.logger.info(
+                    f"{value} is already a picklist value on {field}. Skipping over..."
+                )
 
             else:
                 picklist_values_xml += picklist_value_template.format(
-                    name = escape(value), 
-                    default = False, 
-                    label = escape(value)
+                    name=escape(value), default=False, label=escape(value)
                 )
 
         # add "Other", if it exists
@@ -304,10 +337,12 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
                 for picklist in rt["Metadata"]["picklistValues"]:
                     if picklist["picklist"] == field:
                         for picklist_value in picklist["values"]:
-                            values_added_to_record_type.append(picklist_value["valueName"].lower())
+                            values_added_to_record_type.append(
+                                picklist_value["valueName"].lower()
+                            )
                             record_type_picklist_values_xml += record_type_picklist_value_template.format(
-                                name = escape(picklist_value["valueName"]),
-                                default = picklist_value["default"]
+                                name=escape(picklist_value["valueName"]),
+                                default=picklist_value["default"],
                             )
                         break
 
@@ -318,21 +353,24 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
                         continue
 
                     record_type_picklist_values_xml += record_type_picklist_value_template.format(
-                        name = escape(value),
-                        default = False
+                        name=escape(value), default=False
                     )
 
                 # only include the description if there's a value -- if it's blank, an error is thrown if the record type is managed
                 record_type_description = ""
                 if rt["Metadata"]["description"] != None:
-                    record_type_description = "<description>{}</description>".format(escape(rt["Metadata"]["description"]))
+                    record_type_description = "<description>{}</description>".format(
+                        escape(rt["Metadata"]["description"])
+                    )
 
                 record_type_picklist_xml += record_type_picklist_template.format(
-                    name = rt["FullName"].split('.')[1], # removes the SObject from FullName
-                    description = record_type_description,
-                    label = escape(rt["Name"]), 
-                    field = field,
-                    picklist_values = record_type_picklist_values_xml
+                    name=rt["FullName"].split(".")[
+                        1
+                    ],  # removes the SObject from FullName
+                    description=record_type_description,
+                    label=escape(rt["Name"]),
+                    field=field,
+                    picklist_values=record_type_picklist_values_xml,
                 )
 
         sorted_picklist = validated_field["valueSet"]["valueSetDefinition"]["sorted"]
@@ -342,7 +380,9 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         # only include the object description if there's a value -- if it's blank, an error is thrown if the object is managed
         object_description = ""
         if validated_field["description"] != None:
-            object_description = "<description>{}</description>".format(escape(validated_field["description"]))
+            object_description = "<description>{}</description>".format(
+                escape(validated_field["description"])
+            )
 
         object_help_text = ""
         if validated_field["inlineHelpText"] != None:
@@ -350,13 +390,14 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
 
         # combine it all together
         object_xml = object_template.format(
-            field = field,
-            description = object_description,
-            helpText = object_help_text,
-            label = escape(validated_field["label"]),
-            sorted = sorted_picklist,
-            picklist_values = picklist_values_xml,
-            record_types = record_type_picklist_xml
+            restricted=self.options["restricted"],
+            field=field,
+            description=object_description,
+            helpText=object_help_text,
+            label=escape(validated_field["label"]),
+            sorted=sorted_picklist,
+            picklist_values=picklist_values_xml,
+            record_types=record_type_picklist_xml,
         )
 
         return object_xml

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -85,6 +85,10 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             "description": "The record types for which these new picklist values will be available",
             "required": False,
         },
+        "existing_values": {
+            "description": "The record types for which these new picklist values will be available",
+            "required": False,
+        },
         "sorted": {
             "description": "If true, sets the entire picklist to be sorted in alphabetical order",
             "required": False,
@@ -270,15 +274,14 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         picklist_values_xml = ""
         record_type_picklist_xml = ""
         other_picklist_xml = ""
-
         values_added = []
         # add the existing picklist values
         for existing_picklist_value in existing_picklist_values:
             values_added.append(existing_picklist_value["label"].lower())
             # if it exists, should "Other" remain at the bottom of the picklist?
             if (
-                existing_picklist_value["label"] == "On Campus"
-                or existing_picklist_value["label"] == "Off Campus"
+                "existing_values" in self.options
+                and existing_picklist_value["label"] in self.options["existing_values"]
             ):
                 continue
             if existing_picklist_value["label"] == "Other":

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -95,11 +95,11 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             "required": False,
         },
         "restricted": {
-            "description": "If picklist value is a required field",
+            "description": "If true, sets each picklist value to be a restricted field",
             "required": False,
         },
         "namespaced": {
-            "description": "If picklist value is a required field",
+            "description": "If true, sets the org to a namespaced context",
             "required": False,
         },
     }
@@ -314,13 +314,6 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
 
         # add the new picklist values
         for value in self.options["values"]:
-            # ignore any existing picklist values
-            # if value.lower() in values_added:
-            #     self.logger.info(
-            #         f"{value} is already a picklist value on {field}. Skipping over..."
-            #     )
-
-            # else:
             picklist_values_xml += picklist_value_template.format(
                 name=escape(value), default=False, label=escape(value)
             )

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -319,20 +319,28 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             for rt in picklist_record_types:
                 record_type_picklist_values_xml = ""
                 values_added_to_record_type = []
+                other_record_type_picklist_values_xml = ""
 
                 # add back the existing picklist values assigned to the record type
                 for picklist in rt["Metadata"]["picklistValues"]:
+                    
                     if picklist["picklist"] == field:
                         for picklist_value in picklist["values"]:
                             values_added_to_record_type.append(
                                 picklist_value["valueName"].lower()
                             )
-                            record_type_picklist_values_xml += record_type_picklist_value_template.format(
+                            if picklist["values"][0]["valueName"] == "Other": 
+                                other_record_type_picklist_values_xml += record_type_picklist_value_template.format(
                                 name=escape(picklist_value["valueName"]),
                                 default=picklist_value["default"],
                             )
+                            else:
+                                record_type_picklist_values_xml += record_type_picklist_value_template.format(
+                                    name=escape(picklist_value["valueName"]),
+                                    default=picklist_value["default"],
+                                )
                         break
-
+                            
                 # assign the new picklist values to the record type
                 for value in self.options["values"]:
                     # ignore any existing picklist values
@@ -342,7 +350,9 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
                     record_type_picklist_values_xml += record_type_picklist_value_template.format(
                         name=escape(value), default=False
                     )
-
+            
+                record_type_picklist_values_xml += other_record_type_picklist_values_xml  
+                print(record_type_picklist_values_xml)   
                 # only include the description if there's a value -- if it's blank, an error is thrown if the record type is managed
                 record_type_description = ""
                 if rt["Metadata"]["description"] != None:

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -54,6 +54,7 @@ picklist_value_template = """
 record_type_picklist_template = """
     <recordTypes>
         <fullName>{name}</fullName>
+        {business_process}
         <active>true</active>
         {description}
         <label>{label}</label>
@@ -94,10 +95,6 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         },
         "restricted": {
             "description": "If picklist value is a required field",
-            "required": False,
-        },
-        "buisness_process": {
-            "description": "If picklist value is a business_process",
             "required": False,
         },
     }
@@ -362,8 +359,13 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
                     record_type_description = "<description>{}</description>".format(
                         escape(rt["Metadata"]["description"])
                     )
+                if rt["Metadata"]["businessProcess"] != None:
+                    record_type_business_process = "<businessProcess>{}</businessProcess>".format(
+                        escape(rt["Metadata"]["businessProcess"])
+                    )
 
                 record_type_picklist_xml += record_type_picklist_template.format(
+                    business_process=record_type_business_process,
                     name=rt["FullName"].split(".")[
                         1
                     ],  # removes the SObject from FullName

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -272,11 +272,15 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         other_picklist_xml = ""
 
         values_added = []
-
         # add the existing picklist values
         for existing_picklist_value in existing_picklist_values:
             values_added.append(existing_picklist_value["label"].lower())
             # if it exists, should "Other" remain at the bottom of the picklist?
+            if (
+                existing_picklist_value["label"] == "On Campus"
+                or existing_picklist_value["label"] == "Off Campus"
+            ):
+                continue
             if existing_picklist_value["label"] == "Other":
                 other_picklist_xml = picklist_value_template.format(
                     name=existing_picklist_value["valueName"],
@@ -294,15 +298,15 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         # add the new picklist values
         for value in self.options["values"]:
             # ignore any existing picklist values
-            if value.lower() in values_added:
-                self.logger.info(
-                    f"{value} is already a picklist value on {field}. Skipping over..."
-                )
+            # if value.lower() in values_added:
+            #     self.logger.info(
+            #         f"{value} is already a picklist value on {field}. Skipping over..."
+            #     )
 
-            else:
-                picklist_values_xml += picklist_value_template.format(
-                    name=escape(value), default=False, label=escape(value)
-                )
+            # else:
+            picklist_values_xml += picklist_value_template.format(
+                name=escape(value), default=False, label=escape(value)
+            )
 
         # add "Other", if it exists
         picklist_values_xml += other_picklist_xml

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -358,7 +358,6 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
                     )
 
                 record_type_picklist_values_xml += other_record_type_picklist_values_xml
-                print(record_type_picklist_values_xml)
                 # only include the description if there's a value -- if it's blank, an error is thrown if the record type is managed
                 record_type_description = ""
                 if rt["Metadata"]["description"] != None:

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -89,10 +89,6 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             "description": "If true, sets the entire picklist to be sorted in alphabetical order",
             "required": False,
         },
-        "otherlast": {
-            "description": "If true, the Other value (if one exists) will remain at the end of the values",
-            "required": False,
-        },
         "restricted": {
             "description": "If picklist value is a required field",
             "required": False,
@@ -109,16 +105,6 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
             self.options.get("restricted", False)
         )
         self.options["sorted"] = process_bool_arg(self.options.get("sorted", False))
-        self.options["otherlast"] = process_bool_arg(
-            self.options.get("otherlast", False)
-        )
-
-        if self.options["sorted"] and self.options["otherlast"]:
-            raise TaskOptionsError(
-                f"The sorted option and otherlast option cannot both be set to true. "
-                "To sort a picklist but leave Other at the end, run the task twice: once to add the new values, sorted alphabetically, "
-                "and again to set Other at the end."
-            )
 
     # Adds picklist values to the given field, if they don't already exist.
     # Optionally adds the picklist values for the specified record types, if the record types exist.
@@ -291,10 +277,7 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
         for existing_picklist_value in existing_picklist_values:
             values_added.append(existing_picklist_value["label"].lower())
             # if it exists, should "Other" remain at the bottom of the picklist?
-            if (
-                existing_picklist_value["label"] == "Other"
-                and self.options["otherlast"]
-            ):
+            if existing_picklist_value["label"] == "Other":
                 other_picklist_xml = picklist_value_template.format(
                     name=existing_picklist_value["valueName"],
                     default=existing_picklist_value["default"],


### PR DESCRIPTION
# Critical Changes

# Changes
## New Behavior Response-Related Picklist Values
We've added new picklist values to the existing "Type" field on Behavior Response. 
- Detention
- Expulsion with Services
- In-School Suspension
- Out-of-School Suspension
- Removal from Classroom

We've also added these picklist values to the existing "Location" field on Case for Behavior Response. 
- Administrative offices area
- Athletic field or playground
- Auditorium
- Bus stop
- Cafeteria area
- Classroom
- Computer lab
- Hallway or stairs
-  Library/media center
- Locker room or gym areas
- Online
- Parking lot
- Restroom
- School bus
- Stadium
- Unknown
- Walking to or from school

For new installations, the new picklist values are automatically included. If you installed an earlier EDA release, manually add the new picklist values to the "Type" field on Behavior Response and to the "Location" field on Case for Behavior Response as indicated above. For information, check out [Add Custom Fields and Picklist Values](https://powerofus.force.com/s/article/EDA-Add-Custom-Picklist-Values).

# Issues Closed
Closes #198
# New Metadata
New picklist values for hed__Type__c on Behavior Response: 
- Detention
- Expulsion with Services
- In-School Suspension
- Out-of-School Suspension
- Removal from Classroom

New picklist values for hed__Location__c on Case: 
- Administrative offices area
- Athletic field or playground
- Auditorium
- Bus stop
- Cafeteria area
- Classroom
- Computer lab
- Hallway or stairs
-  Library/media center
- Locker room or gym areas
- Online
- Parking lot
- Restroom
- School bus
- Stadium
- Unknown
- Walking to or from school

# Deleted Metadata

# Testing Notes
Dev org: 
- Create a dev org and run dev_org flow and check that the new picklist values are showing up alphabetically and that "Other" is set at the end of the list. For Hed__Location__c, checking the picklist values via Incident record type, the "Other" is not set at the end of the list. 

Trial org: 
- Create a trial org and run trial_org flow and check that the new picklist values are showing up alphabetically and that "Other" is set at the end of the list. For Hed__Location__c, checking the picklist values via Incident record type, the "Other" is not set at the end of the list. 

- Create a trial org and run net_new_org flow and check that the new picklist values are showing up alphabetically and that "Other" is set at the end of the list. For Hed__Location__c, checking the picklist values via Incident record type, the "Other" is not set at the end of the list. 