### PR TITLE
[K12] Update the API version number K12 wide

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -3,7 +3,7 @@ project:
     name: Athena
     package:
         name: K-12 Architecture Kit
-        api_version: '45.0'
+        api_version: '48.0'
         namespace: k12kit
         install_class: STG_InstallScript
     git:

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,5 +1,5 @@
 {
-  "sourceApiVersion": "45.0",
+  "sourceApiVersion": "48.0",
   "packageDirectories": [
     {
       "default": true,

--- a/src/classes/CON_CurrentGradeLevel_TDTM.cls-meta.xml
+++ b/src/classes/CON_CurrentGradeLevel_TDTM.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <packageVersions>
         <majorNumber>1</majorNumber>
         <minorNumber>91</minorNumber>

--- a/src/classes/CON_CurrentGradeLevel_TEST.cls-meta.xml
+++ b/src/classes/CON_CurrentGradeLevel_TEST.cls-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <packageVersions>
         <majorNumber>1</majorNumber>
         <minorNumber>91</minorNumber>

--- a/src/classes/GRER_SyncGradeLevel_TDTM.cls-meta.xml
+++ b/src/classes/GRER_SyncGradeLevel_TDTM.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/GRER_SyncGradeLevel_TEST.cls-meta.xml
+++ b/src/classes/GRER_SyncGradeLevel_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_InstallScript.cls-meta.xml
+++ b/src/classes/STG_InstallScript.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/STG_InstallScript_TEST.cls-meta.xml
+++ b/src/classes/STG_InstallScript_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_DefaultConfig.cls-meta.xml
+++ b/src/classes/TDTM_DefaultConfig.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/TDTM_ProcessControl.cls-meta.xml
+++ b/src/classes/TDTM_ProcessControl.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace.cls-meta.xml
+++ b/src/classes/UTIL_Namespace.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/UTIL_Namespace_TEST.cls-meta.xml
+++ b/src/classes/UTIL_Namespace_TEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -134,5 +134,5 @@
         <members>fr</members>
         <name>Translations</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/src/tabs/Grade_Enrollment__c.tab
+++ b/src/tabs/Grade_Enrollment__c.tab
@@ -2,6 +2,5 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
     <description>Tracks students&apos; enrollments in a particular grade at a given educational institution.</description>
-    <mobileReady>false</mobileReady>
     <motif>Custom62: Chalkboard</motif>
 </CustomTab>

--- a/src/triggers/TDTM_GradeEnrollment.trigger-meta.xml
+++ b/src/triggers/TDTM_GradeEnrollment.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -16,7 +16,7 @@ package_xml_template = """<?xml version="1.0" encoding="UTF-8"?>
         <members>{object}.{field}</members>
         <name>CustomField</name>
     </types>{record_types_block}
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>"""
 
 package_xml_record_types_block_template = """

--- a/tasks/add_picklist_values.py
+++ b/tasks/add_picklist_values.py
@@ -111,7 +111,7 @@ class AddPicklistValues(BaseSalesforceApiTask, Deploy):
     # Optionally adds the picklist values for the specified record types, if the record types exist.
     # Optionally updates the picklist values to be alphabetical.
     def _run_task(self):
-        self.api_version = "47.0"
+        self.api_version = "48.0"
         sobject = self.options["sobject"]
         field = self.options["field"]
 

--- a/tasks/legacy_update_profile.py
+++ b/tasks/legacy_update_profile.py
@@ -24,7 +24,7 @@ DEFAULT_XML = """<Package xmlns="http://soap.sforce.com/2006/04/metadata">
         <members>Admin</members>
         <name>Profile</name>
     </types>
-    <version>39.0</version>
+    <version>48.0</version>
 </Package>"""
 
 
@@ -212,7 +212,7 @@ class UpdateProfile(Deploy):
 
     def _get_deploy_package_xml_content(self):
         return f"""<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata">
-        <types><members>{self.profile_name}</members><name>Profile</name></types><version>39.0</version></Package>
+        <types><members>{self.profile_name}</members><name>Profile</name></types><version>48.0</version></Package>
         """
 
     def _deploy_metadata(self):

--- a/tasks/test_add_picklist_values.py
+++ b/tasks/test_add_picklist_values.py
@@ -119,7 +119,7 @@ expected_recordtypes_query_response = {
     "size": 2,
 }
 
-api_version = "47.0"
+api_version = "48.0"
 
 
 class TestAddPicklistValues(unittest.TestCase):

--- a/unpackaged/config/installer/package.xml
+++ b/unpackaged/config/installer/package.xml
@@ -4,5 +4,5 @@
         <members>*</members>
         <name>Profile</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/config/trial/package.xml
+++ b/unpackaged/config/trial/package.xml
@@ -107,5 +107,5 @@
         <members>unfiled$public/Term_Grades_Grouped_by_Student_and_Term</members>
         <name>Report</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/post/config/package.xml
+++ b/unpackaged/post/config/package.xml
@@ -125,5 +125,5 @@
         <members>OrgPreference</members>
         <name>Settings</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>

--- a/unpackaged/post/config/package.xml
+++ b/unpackaged/post/config/package.xml
@@ -122,7 +122,7 @@
         <name>Report</name>
     </types>
     <types>
-        <members>OrgPreference</members>
+        <members>Language</members>
         <name>Settings</name>
     </types>
     <version>48.0</version>

--- a/unpackaged/post/config/settings/Language.settings
+++ b/unpackaged/post/config/settings/Language.settings
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageSettings xmlns="http://soap.sforce.com/2006/04/metadata">
+    <enableTranslationWorkbench>true</enableTranslationWorkbench>
+</LanguageSettings>

--- a/unpackaged/post/config/settings/OrgPreference.settings
+++ b/unpackaged/post/config/settings/OrgPreference.settings
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<OrgPreferenceSettings xmlns="http://soap.sforce.com/2006/04/metadata">
-    <preferences>
-        <settingName>Translation</settingName>
-        <settingValue>true</settingValue>
-    </preferences>
-</OrgPreferenceSettings>

--- a/unpackaged/pre/recordtypes/package.xml
+++ b/unpackaged/pre/recordtypes/package.xml
@@ -7,5 +7,5 @@
         <members>Contact.Student</members>
         <name>RecordType</name>
     </types>
-    <version>45.0</version>
+    <version>48.0</version>
 </Package>


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated K-12 Architecture Kit to use API Version v48.0 to align with the most current version of the API. Additionally, we have removed references to the deprecated mobileReady attribute from the Grade Enrollment tab. We've replaced the Translation preference in the deprecated OrgPreference.settings component with the enableTranslationWorkbench field in the Language.settings component. You'll see no change to your org as a result of this update.


# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
