### PR TITLE
[K12-kit] Hot fix for existing values in add_behavior_response_type_v…

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -103,6 +103,7 @@ tasks:
             sobject: hed__Behavior_Response__c
             field: hed__Type__c
             values: "Detention,Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
+            existing_values: "Detention,Expulsion with Services,In-School Suspension,Out-of-School Suspension,Removal from Classroom"
             restricted: true
             sorted: True
             namespaced: False
@@ -116,7 +117,7 @@ tasks:
             sobject: Case
             field: hed__Location__c
             values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus,On Campus,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
-            existing_values: "Off Campus, On Campus"
+            existing_values: "Administrative Offices Area,Athletic Field or Playground,Auditorium,Bus Stop,Cafeteria Area,Classroom,Computer Lab,Hallway or Stairs,Library/Media Center,Locker Room or Gym Areas,Off Campus,On Campus,Online,Parking Lot,Restroom,School Bus,Stadium,Unknown,Walking to or from School"
             recordtypes: Incident
             restricted: true
             sorted: True


### PR DESCRIPTION
…alues and add_case_location_values, this fix will be deprecated with MetadataETL implementation.

As a result of existing values being missed, this change needs to be merged for the successful run of `trial_org` flow against an org with pre-existing picklist values.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
