### PR TITLE
[K12] Build Issue with "School Days Missed" Field on BEH Page Layout

### DIFF
--- a/unpackaged/config/trial/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
+++ b/unpackaged/config/trial/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
@@ -43,7 +43,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>School_Days_Missed__c</field>
+                <field>%%%NAMESPACE%%%School_Days_Missed__c%%%NAMESPACE%%%</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/unpackaged/config/trial/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
+++ b/unpackaged/config/trial/layouts/hed__Behavior_Response__c-K12 Kit Behavior Response Layout.layout
@@ -43,7 +43,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>%%%NAMESPACE%%%School_Days_Missed__c%%%NAMESPACE%%%</field>
+                <field>%%%NAMESPACE%%%School_Days_Missed__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>


### PR DESCRIPTION
# Critical Changes

# Changes
Updated the field reference in the BEH page layout in trial folder from School_Days_Missed__c to %%%NAMESPACE%%%School_Days_Missed__c. 
# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes


# Unaggregated Pull Requests
* Merge feature/positiveBehavior into feature/positiveBehavior__kdyBR [[PR226](https://github.com/SalesforceFoundation/k12-architecture-kit/pull/226)]