### PR TITLE
[K12] Update labels/descriptions to match EDA's latest updates

### DIFF
--- a/unpackaged/config/trial/objects/hed__Course_Offering__c.object
+++ b/unpackaged/config/trial/objects/hed__Course_Offering__c.object
@@ -34,7 +34,7 @@
         <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Joins Courses and Terms to contain information related to a single occurrence of a course.</description>
+    <description>Joins Courses and Terms to contain information related to a single occurrence of a Course.</description>
     <label>Course Offering</label>
     <nameField>
         <label>Course Offering ID</label>

--- a/unpackaged/config/trial/objects/hed__Course__c.object
+++ b/unpackaged/config/trial/objects/hed__Course__c.object
@@ -32,6 +32,7 @@
         <fullName>hed__Account__c</fullName>
         <externalId>false</externalId>
         <label>Department</label>
+        <description>The department (Account record) that offers this Course.</description>
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Courses</relationshipLabel>
         <relationshipName>Courses</relationshipName>

--- a/unpackaged/post/config/objects/hed__Course_Offering__c.object
+++ b/unpackaged/post/config/objects/hed__Course_Offering__c.object
@@ -34,7 +34,7 @@
         <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Joins Courses and Terms to contain information related to a single occurrence of a course.</description>
+    <description>Joins Courses and Terms to contain information related to a single occurrence of a Course.</description>
     <label>Course Offering</label>
     <nameField>
         <label>Course Offering ID</label>

--- a/unpackaged/post/config/objects/hed__Course__c.object
+++ b/unpackaged/post/config/objects/hed__Course__c.object
@@ -32,6 +32,7 @@
         <fullName>hed__Account__c</fullName>
         <externalId>false</externalId>
         <label>Department</label>
+        <description>The department (Account record) that offers this Course.</description>
         <referenceTo>Account</referenceTo>
         <relationshipLabel>Courses</relationshipLabel>
         <relationshipName>Courses</relationshipName>


### PR DESCRIPTION
# Critical Changes

# Changes
We've updated descriptions on fields to match with EDA's descriptions. With this change we corrected casing of "Course" in the object description for Course Offering and added description to the field 'hed__Account__c' on 'Course' object.

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
