### PR TITLE
Unit Test Fixes for Education History Warning Message

### DIFF
--- a/src/classes/EDUHIS_DataInteg_TDTM.cls
+++ b/src/classes/EDUHIS_DataInteg_TDTM.cls
@@ -79,7 +79,7 @@ global with sharing class EDUHIS_DataInteg_TDTM extends hed.TDTM_Runnable {
         Map<Id, hed__Education_History__c> oldEdHistById = new Map<Id, hed__Education_History__c>((List<hed__Education_History__c>)oldSObjectsList);
 
         Set<Id> relevantEducationHistIdsSet = new Set<Id>();
-        List<hed__Education_History__c> eduHistoryWithErrorsList = new List<hed__Education_History__c>();
+        Map<Id,hed__Education_History__c> eduHistorybyIdWithErrors = new Map<Id,hed__Education_History__c>();
 
         for (hed__Education_History__c eduHist : newEdHistById.values()){
             if (String.isBlank(eduHist.hed__Account__c) == true || eduHist.hed__Account__c == oldEdHistById.get(eduHist.Id).hed__Account__c){
@@ -105,10 +105,10 @@ global with sharing class EDUHIS_DataInteg_TDTM extends hed.TDTM_Runnable {
                 continue;
             }
 
-            eduHistoryWithErrorsList.add(eduHistInContext);
+            eduHistorybyIdWithErrors.put(eduHistInContext.Id,eduHistInContext);
             eduHistInContext.addError(Label.EduHisInstitutionMismatch);
         }
 
-        return eduHistoryWithErrorsList;
+        return eduHistorybyIdWithErrors.values();
     }
 }

--- a/src/classes/EDUHIS_DataInteg_TEST.cls
+++ b/src/classes/EDUHIS_DataInteg_TEST.cls
@@ -612,11 +612,11 @@ private class EDUHIS_DataInteg_TEST {
 
         for (hed__Education_History__c eduHist : educationHistoryList){
             Grade_Enrollment__c gradeEnrollMatching = new Grade_Enrollment__c(Contact__c = testContact.Id,
-                                                                              Educational_Institution__c = firstAccount.Id,
+                                                                              Educational_Institution__c = secondAccount.Id,
                                                                               Grade_Level__c = 'Eighth Grade',
                                                                               Education_History__c = eduHist.Id);
 
-            Grade_Enrollment__c gradeEnrollMisMatching = new Grade_Enrollment__c(Contact__c = testContact.Id,
+            Grade_Enrollment__c gradeEnrollMatching2 = new Grade_Enrollment__c(Contact__c = testContact.Id,
                                                                                   Educational_Institution__c = secondAccount.Id,
                                                                                   Grade_Level__c = 'Eighth Grade',
                                                                                   Education_History__c = eduHist.Id);
@@ -627,7 +627,7 @@ private class EDUHIS_DataInteg_TEST {
                                                                           Education_History__c = eduHist.Id);
 
             gradeEnrollmentsList.add(gradeEnrollMatching);
-            gradeEnrollmentsList.add(gradeEnrollMisMatching);
+            gradeEnrollmentsList.add(gradeEnrollMatching2);
             gradeEnrollmentsList.add(gradeEnrollNull);
         }
 
@@ -702,7 +702,7 @@ private class EDUHIS_DataInteg_TEST {
                                                                       Education_History__c = eduHist.Id);
 
             Grade_Enrollment__c gradeEnroll2 = new Grade_Enrollment__c(Contact__c = testContact.Id,
-                                                                     Educational_Institution__c = secondAccount.Id,
+                                                                     Educational_Institution__c = firstAccount.Id,
                                                                      Grade_Level__c = 'Eighth Grade',
                                                                      Education_History__c = eduHist.Id);
 
@@ -872,8 +872,8 @@ private class EDUHIS_DataInteg_TEST {
                                                                               Grade_Level__c = 'Eighth Grade',
                                                                               Education_History__c = eduHist.Id);
 
-            Grade_Enrollment__c gradeEnrollMismatching = new Grade_Enrollment__c(Contact__c = testContact.Id,
-                                                                                 Educational_Institution__c = firstAccount.Id,
+            Grade_Enrollment__c gradeEnrollMatching2 = new Grade_Enrollment__c(Contact__c = testContact.Id,
+                                                                                 Educational_Institution__c = secondAccount.Id,
                                                                                  Grade_Level__c = 'Eighth Grade',
                                                                                  Education_History__c = eduHist.Id);
 
@@ -882,18 +882,18 @@ private class EDUHIS_DataInteg_TEST {
                                                                           Grade_Level__c = 'Eighth Grade',
                                                                           Education_History__c = eduHist.Id);
             gradeEnrollmentsList.add(gradeEnrollMatching);
-            gradeEnrollmentsList.add(gradeEnrollMismatching);
+            gradeEnrollmentsList.add(gradeEnrollMatching2);
             gradeEnrollmentsList.add(gradeEnrollNull);
         }
 
         insert gradeEnrollmentsList;
 
         for (hed__Education_History__c newEdHist : educationHistoryList){
-            newSObjectsList.add((SObject)newEdHist);
-
             hed__Education_History__c oldEdHist = newEdHist.clone(true);
-            oldEdHist.hed__Account__c = firstAccount.Id;
             oldSObjectsList.add((SObject)oldEdHist);
+
+            newEdHist.hed__Account__c = firstAccount.Id;
+            newSObjectsList.add((SObject)newEdHist);
         }
 
         EDUHIS_DataInteg_TDTM eduHisTdtm = new EDUHIS_DataInteg_TDTM();

--- a/src/classes/EDUHIS_DataInteg_TEST.cls
+++ b/src/classes/EDUHIS_DataInteg_TEST.cls
@@ -934,7 +934,7 @@ private class EDUHIS_DataInteg_TEST {
     **********************************************************************************************************/
     private static void disableGradeEnrollDataIntegTrigger(){
         for (hed.TDTM_Global_API.TdtmToken tdtmToken : hed.TDTM_Global_API.getTdtmConfig()){
-            if (tdtmToken.className == 'GRER_DataInteg_TDTM'){
+            if (tdtmToken.className == UTIL_Namespace.StrTokenNSPrefixDotNotation('GRER_DataInteg_TDTM')){
                 tdtmToken.active = false;
             }
         }

--- a/src/classes/GRER_DataInteg_TDTM.cls
+++ b/src/classes/GRER_DataInteg_TDTM.cls
@@ -63,8 +63,8 @@ global with sharing class GRER_DataInteg_TDTM extends hed.TDTM_Runnable {
             return null;
         }
 
-        if (triggerAction == hed.TDTM_Runnable.Action.BeforeUpdate) {
-            gradeEnrollmentsWithErrorsList = this.handleBeforeUpdate(newList, oldList);
+        if (triggerAction == hed.TDTM_Runnable.Action.AfterUpdate) {
+            gradeEnrollmentsWithErrorsList = this.handleAfterUpdate(newList, oldList);
             return null;
         }
 
@@ -91,7 +91,8 @@ global with sharing class GRER_DataInteg_TDTM extends hed.TDTM_Runnable {
     * @return A list of Grade Enrollment records with errors.
     **********************************************************************************************************************/
     @TestVisible
-    private List<Grade_Enrollment__c> handleBeforeUpdate(List<SObject> newSObjectsList, List<SObject> oldSObjectsList){
+    private List<Grade_Enrollment__c> handleAfterUpdate(List<SObject> newSObjectsList, List<SObject> oldSObjectsList){
+        System.debug('MK DEBUG: executing Before Update');
         Map<Id,Grade_Enrollment__c> newGradeEnrollmentsById = new Map<Id,Grade_Enrollment__c>((List<Grade_Enrollment__c>)newSObjectsList);
         Map<Id,Grade_Enrollment__c> oldGradeEnrollmentsById = new Map<Id,Grade_Enrollment__c>((List<Grade_Enrollment__c>)oldSObjectsList);
 
@@ -160,10 +161,15 @@ global with sharing class GRER_DataInteg_TDTM extends hed.TDTM_Runnable {
         
         for (Grade_Enrollment__c gradeEnroll : newGradeEnrollmentsById.values()){
             Grade_Enrollment__c oldGradeEnroll = oldGradeEnrollmentsById.get(gradeEnroll.Id);
-
-            if (String.isBlank(gradeEnroll.Educational_Institution__c)  == true || gradeEnroll.Educational_Institution__c == oldGradeEnroll.Educational_Institution__c){
+            
+            if (String.isBlank(gradeEnroll.Educational_Institution__c) == true || String.isBlank(gradeEnroll.Education_History__c) == true){
+                continue;
+            }  
+            
+            if (gradeEnroll.Educational_Institution__c == oldGradeEnroll.Educational_Institution__c && gradeEnroll.Education_History__c == oldGradeEnroll.Education_History__c ){
                 continue;
             }
+
             relevantGradeEnrollIdsSet.add(gradeEnroll.Id);
         }
 
@@ -173,14 +179,14 @@ global with sharing class GRER_DataInteg_TDTM extends hed.TDTM_Runnable {
                                                                          Educational_Institution__c
                                                                   FROM Grade_Enrollment__c
                                                                   WHERE Educational_Institution__c != null 
+                                                                  AND Education_History__c != null
                                                                   AND Education_History__r.hed__Account__c != null
                                                                   AND Id IN :relevantGradeEnrollIdsSet];
 
         for (Grade_Enrollment__c gradeEnroll : relevantGradeEnrollmentsList){
-
             Grade_Enrollment__c gradeEnrollInContext = newGradeEnrollmentsById.get(gradeEnroll.Id);
 
-            if (gradeEnroll.Educational_Institution__c == gradeEnrollInContext.Education_History__r.hed__Account__c){
+            if (gradeEnrollInContext.Educational_Institution__c == gradeEnroll.Education_History__r.hed__Account__c){
                 continue;
             }
 

--- a/src/classes/GRER_DataInteg_TEST.cls
+++ b/src/classes/GRER_DataInteg_TEST.cls
@@ -709,12 +709,12 @@ private class GRER_DataInteg_TEST {
     **********************************************************************************************************/
 
     /*********************************************************************************************************
-    * @description Test to verify that method handleBeforeUpdate() successfully processes updates to Grade 
+    * @description Test to verify that method handleAfterUpdate() successfully processes updates to Grade 
     * Enrollment records when the Education Institution fields match the value specified on the associated
     * Education History records.
     *********************************************************************************************************/
     @isTest 
-    private static void handleBeforeUpdateWithoutMismatch(){
+    private static void handleAfterUpdateWithoutMismatch(){
         hed__Hierarchy_Settings__c hs = hed.UTIL_CustomSettings_API.getSettings();
         String adminRecordType = hs.hed__Administrative_Account_Record_Type__c;
 
@@ -764,19 +764,19 @@ private class GRER_DataInteg_TEST {
         List<Grade_Enrollment__c> gradeEnrollWithErrorList = new List<Grade_Enrollment__c>();
         
         Test.startTest();
-        gradeEnrollWithErrorList = gradeEnrollTdtm.handleBeforeUpdate((List<SObject>)newGradeEnrollmentsList, (List<SObject>)oldGradeEnrollmentsList);
+        gradeEnrollWithErrorList = gradeEnrollTdtm.handleAfterUpdate((List<SObject>)newGradeEnrollmentsList, (List<SObject>)oldGradeEnrollmentsList);
         Test.stopTest();
 
         System.assertEquals(true, gradeEnrollWithErrorList.isEmpty(), 'Updates with matching Education Institution for Education History and Grade Enrollment should not display an error.'); 
     }
 
     /*********************************************************************************************************
-    * @description Test to verify that method handleBeforeUpdate() displays an error message for updates to Grade 
+    * @description Test to verify that method handleAfterUpdate() displays an error message for updates to Grade 
     * Enrollment records with Education Institution fields that do not match the value specified on the associated
     * Education History records.
     *********************************************************************************************************/
     @isTest 
-    private static void handleBeforeUpdateWithMismatch(){
+    private static void handleAfterUpdateWithMismatch(){
         hed__Hierarchy_Settings__c hs = hed.UTIL_CustomSettings_API.getSettings();
         String adminRecordType = hs.hed__Administrative_Account_Record_Type__c;
 
@@ -827,7 +827,7 @@ private class GRER_DataInteg_TEST {
 
         Test.startTest();
         try{
-            gradeEnrollTdtm.handleBeforeUpdate((List<SObject>)newGradeEnrollmentsList, (List<SObject>)oldGradeEnrollmentsList);
+            gradeEnrollTdtm.handleAfterUpdate((List<SObject>)newGradeEnrollmentsList, (List<SObject>)oldGradeEnrollmentsList);
         } catch (DmlException e){
             System.assertEquals(true, e.getMessage().contains(Label.GrErInstitutionMismatch), 'Updating Grade Enrollments with mismatching Educational Institution should display error message.');
         }

--- a/src/classes/GRER_DataInteg_TEST.cls
+++ b/src/classes/GRER_DataInteg_TEST.cls
@@ -1481,7 +1481,7 @@ private class GRER_DataInteg_TEST {
     **********************************************************************************************************/
     private static void disableEducationHistoryDataIntegTrigger(){
         for (hed.TDTM_Global_API.TdtmToken tdtmToken : hed.TDTM_Global_API.getTdtmConfig()){
-            if (tdtmToken.className == 'EDUHIS_DataInteg_TDTM'){
+            if (tdtmToken.className == UTIL_Namespace.StrTokenNSPrefixDotNotation('EDUHIS_DataInteg_TDTM')){
                 tdtmToken.active = false;
             }
         }

--- a/src/classes/TDTM_DefaultConfig.cls
+++ b/src/classes/TDTM_DefaultConfig.cls
@@ -70,7 +70,7 @@ public without sharing class TDTM_DefaultConfig {
                         hed__Load_Order__c = 1,
                         hed__Object__c = Grade_Enrollment__c.SObjectType.getDescribe().getName(),
                         hed__Owned_by_Namespace__c = 'k12kit',
-                        hed__Trigger_Action__c = 'AfterInsert;BeforeUpdate'));
+                        hed__Trigger_Action__c = 'AfterInsert;AfterUpdate'));
 
         handlers.add(new hed__Trigger_Handler__c(
                         hed__Active__c = true,


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Testing Notes
*Fixed tests for the Education History unit tests.
*Added non-significant change to return a unique list of education histories that are in an error state rather than the same education history for every grade enrollment mismatch