### PR TITLE
Update to current task name

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -325,7 +325,7 @@ flows:
                    managed: True
                    namespace: hed
             6:
-                task: github_parent_to_children
+                task: github_automerge_feature
 
     config_managed:
         #description: Configure an org for use as a dev org after package metadata is deployed


### PR DESCRIPTION
CumulusCI v3.20.0 renamed `github_parent_to_child` to `github_automerge_feature`. Apologies I didn't catch this earlier.

Currently causing builds to fail like this:
https://sfdo-metaci.herokuapp.com/builds/322654/flows