### PR TITLE
QA Org 2gp Does Not Use Managed Configuration

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -318,7 +318,8 @@ tasks:
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
         group: "K-12: Custom Settings"
         options:
-            apex: STG_InstallScript.setK12kitDefaultTriggerHandlers();
+            path: scripts/configure_k12_kit.cls
+            apex: executeInstallApex();
 
     github_release_notes:
         options:
@@ -419,14 +420,19 @@ flows:
                 flow: None
             2:
                 task: deploy_post
+                when: "'k12kit' in org_config.installed_packages"
             3:
                 task: deploy_k12_kit_settings
+                when: "'k12kit' in org_config.installed_packages"
             4:
                 task: enable_course_connections
+                when: "'k12kit' in org_config.installed_packages"
             5:
                 task: deploy_trial_config
+                when: "'k12kit' in org_config.installed_packages"
             6:
                 task: update_admin_profile
+                when: "'k12kit' in org_config.installed_packages"
 
     dependencies:
         steps:
@@ -441,12 +447,16 @@ flows:
         steps:
             1:
                 task: enable_course_connections
+                when: "'k12kit' not in org_config.installed_packages"
             2:
                 task: deploy_trial_config
+                when: "'k12kit' not in org_config.installed_packages"
             3:
                 task: deploy_k12_kit_settings
+                when: "'k12kit' not in org_config.installed_packages"
             4:
                 task: execute_install_apex
+                when: "'k12kit' not in org_config.installed_packages"
 
     config_dev:
         steps:
@@ -457,6 +467,8 @@ flows:
         steps:
             3:
                 flow: config_unmanaged
+            4:
+                flow: config_regression
 
     dev_org_namespaced:
         description: Set up a namespaced scratch org as a development environment for unmanaged metadata

--- a/scripts/configure_k12_kit.cls
+++ b/scripts/configure_k12_kit.cls
@@ -1,3 +1,8 @@
+//Runs install apex scripts for unmanaged contexts
+public static void executeInstallApex() {
+    %%%NAMESPACE_DOT%%%STG_InstallScript.setK12kitDefaultTriggerHandlers();
+}
+
 //set the configuration for K-12 Architecture Kit
 //once K-12 has a managed package, this code should move
 public static void initializeK12KitSettings() {


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
Run the qa_org_2gp flow. This made qa_org intelligently work with unmanaged vs managed.