### PR TITLE
Installer config added to regression config

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -431,6 +431,9 @@ flows:
                 task: deploy_trial_config
                 when: "'k12kit' in org_config.installed_packages"
             6:
+                task: deploy_k12_app
+                when: "'k12kit' in org_config.installed_packages"
+            7:
                 task: update_admin_profile
                 when: "'k12kit' in org_config.installed_packages"
 


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

## Unpackaged Metadata

# Deleted Metadata

# Testing Notes
1. Run the qa_org_2gp against a prerelease org shape.
1. Confirm that the K-12 Architecture Kit app is in the app launcher for System Administrator.
